### PR TITLE
add client id param

### DIFF
--- a/message.go
+++ b/message.go
@@ -90,6 +90,7 @@ type Message struct {
 	Dlvtime  string `json:"dlvtime"`  // Optional, Delivery time
 	Vldtime  string `json:"vldtime"`  // Optional
 	Response string `json:"response"` // Optional, Callback URL to receive the delivery receipt of the message
+	ClientID string `json:"clientid"` // Optional, an unique identifier from client to identify SMS message
 }
 
 // ToINI returns the INI format string from the message fields.
@@ -107,6 +108,9 @@ func (m Message) ToINI() string {
 	}
 	if m.Response != "" {
 		ini += "response=" + m.Response + "\n"
+	}
+	if m.ClientID != "" {
+		ini += "ClientID=" + m.ClientID + "\n"
 	}
 	return ini
 }

--- a/message_test.go
+++ b/message_test.go
@@ -14,8 +14,9 @@ func TestMessage_ToINI(t *testing.T) {
 		Dlvtime:  "20170101010000",
 		Vldtime:  "20170101012300",
 		Response: "https://example.com/callback",
+		ClientID: "R123lB29988uDydrjbABCD",
 	}
-	want1 := "dstaddr=0987654321\nsmbody=Test\ndlvtime=20170101010000\nvldtime=20170101012300\nresponse=https://example.com/callback\n"
+	want1 := "dstaddr=0987654321\nsmbody=Test\ndlvtime=20170101010000\nvldtime=20170101012300\nresponse=https://example.com/callback\nClientID=R123lB29988uDydrjbABCD\n"
 	if got := message1.ToINI(); got != want1 {
 		t.Errorf("Message INI is %v, want %v", got, want1)
 	}


### PR DESCRIPTION
In order to identify the sms we sent, we have to provide the UUID ourselves. Mitake will not send the sms more than once if we provide the same UUID within 12 hours.